### PR TITLE
Add support agreements, pricing info, and internal playbooks

### DIFF
--- a/README.md
+++ b/README.md
@@ -432,6 +432,27 @@ The benchmark suite includes:
 
 Results are saved to `artifacts/` with system information, detailed metrics, and simple charts.
 
+## Pricing
+
+| Tier | Price | Features |
+|------|-------|----------|
+| Community | Free | Open-source usage, community support |
+| Professional | $499/month | Standard support, email & Slack, early feature access |
+| Enterprise | Custom | Premium support, integration consulting, training workshops |
+
+## Contact
+
+For inquiries or to request a quote, use the contact form below:
+
+<form action="https://example.com/contact" method="POST">
+  <input type="text" name="name" placeholder="Your Name" required>
+  <input type="email" name="email" placeholder="Your Email" required>
+  <textarea name="message" placeholder="How can we help?" required></textarea>
+  <button type="submit">Send</button>
+</form>
+
+You can also reach us at [support@fractal-down.io](mailto:support@fractal-down.io).
+
 ## License
 
 This project is dual-licensed. You may choose either:

--- a/docs/internal_playbooks/integration_consulting.md
+++ b/docs/internal_playbooks/integration_consulting.md
@@ -1,0 +1,21 @@
+# Integration Consulting Playbook
+
+## Preparation
+- Gather client requirements and system architecture diagrams.
+- Assess compatibility with Fractal-Down and identify integration points.
+- Define success metrics and deliverables.
+
+## Engagement
+- Kick-off meeting with client stakeholders.
+- Develop integration plan with timelines and resource allocation.
+- Set up communication channels and project tracker.
+
+## Delivery
+- Implement integration in iterative milestones.
+- Conduct regular reviews and address blockers promptly.
+- Document configuration and custom code.
+
+## Handover
+- Provide final documentation and training materials.
+- Transfer ownership of deployment and repositories.
+- Schedule follow-up check to ensure stability.

--- a/docs/internal_playbooks/training_workshops.md
+++ b/docs/internal_playbooks/training_workshops.md
@@ -1,0 +1,21 @@
+# Training Workshops Playbook
+
+## Planning
+- Identify target audience and skill levels.
+- Define learning objectives and workshop agenda.
+- Prepare environment requirements and sample datasets.
+
+## Development
+- Create slide deck and hands-on exercises.
+- Draft facilitator notes and troubleshooting tips.
+- Set up feedback forms and evaluation criteria.
+
+## Delivery
+- Conduct workshop with interactive demonstrations.
+- Provide step-by-step labs and monitor participant progress.
+- Collect real-time feedback to adjust pacing.
+
+## Follow-up
+- Share recordings, slides, and code samples.
+- Review feedback and implement improvements.
+- Offer office hours or Q&A sessions for continued support.

--- a/marketing/support_agreements.md
+++ b/marketing/support_agreements.md
@@ -1,0 +1,18 @@
+# Support Agreements
+
+## Basic
+- **Response time:** 48 hours (business days)
+- **Channels:** Community forum or email
+- **Includes:** Access to knowledge base and bug reporting
+
+## Standard
+- **Response time:** 24 hours (business days)
+- **Channels:** Dedicated Slack channel and email
+- **Includes:** Prioritized bug fixes and quarterly check-ins
+
+## Premium
+- **Response time:** 4 hours (business hours)
+- **Channels:** 24/7 phone hotline and dedicated chat
+- **Includes:** Dedicated account manager and guaranteed SLA adherence
+
+*All tiers include access to documentation and product updates.*


### PR DESCRIPTION
## Summary
- Outline Basic, Standard, and Premium support tiers with response times and communication channels
- Introduce pricing table and contact form in README for potential customers
- Provide internal playbooks for integration consulting and training workshops

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68afe6364a5083229490400600444bea

## Summary by Sourcery

Add detailed support agreements, pricing information, and contact form to the README, and introduce internal playbooks for integration consulting and training workshops.

Documentation:
- Add Pricing and Contact sections to README with tiered pricing table and inquiry form
- Add marketing/support_agreements.md outlining Basic, Standard, and Premium support tiers
- Add internal playbooks for integration consulting in docs/internal_playbooks/integration_consulting.md
- Add internal playbooks for training workshops in docs/internal_playbooks/training_workshops.md

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Documentation
  - Added Pricing section with tiered plans: Community (Free), Professional ($499/month), and Enterprise (Custom).
  - Added Contact section with a form (name, email, message) and support email link.
  - Introduced Support Agreements overview: Basic, Standard, and Premium tiers with defined response times and channels.
  - Added Integration Consulting and Training Workshops playbooks outlining phases, steps, and best practices.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->