### PR TITLE
Add license guidance and basic key tracking

### DIFF
--- a/README.md
+++ b/README.md
@@ -440,6 +440,16 @@ Results are saved to `artifacts/` with system information, detailed metrics, and
 | Professional | $499/month | Standard support, email & Slack, early feature access |
 | Enterprise | Custom | Premium support, integration consulting, training workshops |
 
+## Purchase
+
+To purchase a commercial license:
+
+1. Select a tier from the [Pricing](#pricing) table.
+2. Email [sales@fractal-down.io](mailto:sales@fractal-down.io) with your selected plan and expected usage.
+3. Our team will provide an invoice and deliver a license key upon payment.
+
+For legal questions or contract requests, contact [legal@fractal-down.io](mailto:legal@fractal-down.io).
+
 ## Contact
 
 For inquiries or to request a quote, use the contact form below:

--- a/docs/license_comparison.md
+++ b/docs/license_comparison.md
@@ -1,0 +1,15 @@
+# Apache 2.0 vs. Fractal-Down License
+
+This project is offered under a dual-license model. The table below highlights key differences and benefits of the standard Apache 2.0 license compared to the custom Fractal-Down License.
+
+| Feature | Apache License 2.0 | Fractal-Down License |
+| --- | --- | --- |
+| **OSI Approved** | Yes | No (custom, non-OSI) |
+| **Permitted Use** | Broad use, modification, and distribution with notice | Use, modify, and distribute with notice; requires clear attribution of changes |
+| **Patent Grant** | Explicit patent license from contributors | Patent license terminates if you initiate litigation |
+| **Trademark Use** | No trademark rights granted | No trademark rights granted; endorsement restrictions apply |
+| **Warranty** | Provided "as is" without warranty | Provided "as is" without warranty |
+| **Commercial Support** | Not provided by license | Optional commercial support and contract terms available |
+| **Flexibility** | Standard open-source license ideal for general use | Tailored for organizations needing curated contributions and optional paid support |
+
+Both licenses allow adoption of Fractal-Down, but the custom license adds provisions for organizations that need a more controlled contribution model and access to commercial agreements.

--- a/fractal_down/__init__.py
+++ b/fractal_down/__init__.py
@@ -13,6 +13,7 @@ from fractal_down.evaluator import Evaluator, EvalResult
 from fractal_down.binary_plan import save_plan, load_plan
 from fractal_down.cache import get_or_build_plan
 from fractal_down.hashing import get_default_provider
+from fractal_down.license_key import generate_license, verify_license, LicenseRecord
 
 __all__ = [
     "__version__",
@@ -28,4 +29,7 @@ __all__ = [
     "load_plan",
     "get_or_build_plan",
     "get_default_provider",
+    "generate_license",
+    "verify_license",
+    "LicenseRecord",
 ]

--- a/fractal_down/cli.py
+++ b/fractal_down/cli.py
@@ -16,6 +16,7 @@ from fractal_down.fractal import compute_node_priority, FractalParams
 from fractal_down.binary_plan import save_plan, load_plan
 from fractal_down.cache import get_cache_dir, get_or_build_plan
 from fractal_down.examples import make_tiny_dag, demo_run
+from fractal_down.license_key import generate_license, verify_license
 
 
 def main():
@@ -65,6 +66,16 @@ def main():
     clear_parser = subparsers.add_parser("clear-cache", help="Clear cached plans")
     clear_parser.add_argument("--days", type=int, help="Remove plans older than N days")
     clear_parser.add_argument("--count", type=int, help="Keep only N newest plans")
+
+    # license command
+    lic_parser = subparsers.add_parser("license", help="Manage license keys")
+    lic_sub = lic_parser.add_subparsers(dest="license_cmd")
+
+    lic_issue = lic_sub.add_parser("issue", help="Generate a license key")
+    lic_issue.add_argument("--contract", required=True, help="Contract identifier")
+
+    lic_check = lic_sub.add_parser("check", help="Verify a license key")
+    lic_check.add_argument("key", help="License key to check")
 
     # bench command
     bench_parser = subparsers.add_parser(
@@ -149,6 +160,8 @@ def main():
             return cmd_inspect_plan(args.path)
         elif args.command == "clear-cache":
             return cmd_clear_cache(args.days, args.count)
+        elif args.command == "license":
+            return cmd_license(args)
         elif args.command == "bench":
             return cmd_bench(args)
         else:
@@ -333,6 +346,24 @@ def cmd_clear_cache(days: Optional[int], count: Optional[int]) -> int:
     print(f"{remaining} files remaining in cache")
 
     return 0
+
+
+def cmd_license(args) -> int:
+    """Issue or verify license keys."""
+    if args.license_cmd == "issue":
+        record = generate_license(args.contract)
+        print(f"Issued license key: {record.key}")
+        return 0
+    elif args.license_cmd == "check":
+        if verify_license(args.key):
+            print("License key valid")
+            return 0
+        else:
+            print("License key invalid")
+            return 1
+    else:
+        print("No license action specified")
+        return 1
 
 
 def cmd_bench(args) -> int:

--- a/fractal_down/license_key.py
+++ b/fractal_down/license_key.py
@@ -1,0 +1,67 @@
+"""Simple license key and contract tracking for Fractal-Down.
+
+This module provides minimal utilities for issuing and verifying
+license keys. License data is stored in a JSON file on disk and can
+optionally be redirected via the ``FRACTAL_DOWN_LICENSE_FILE``
+environment variable.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import secrets
+from dataclasses import dataclass
+from pathlib import Path
+from typing import List
+
+
+# Resolve license file path, allowing override through environment variable.
+DEFAULT_PATH = Path.home() / ".fractal_down" / "licenses.json"
+LICENSE_FILE = Path(os.environ.get("FRACTAL_DOWN_LICENSE_FILE", DEFAULT_PATH))
+
+
+@dataclass
+class LicenseRecord:
+    """A stored license key tied to a contract identifier."""
+
+    key: str
+    contract: str
+
+
+def _ensure_storage() -> None:
+    """Ensure the storage directory exists."""
+    LICENSE_FILE.parent.mkdir(parents=True, exist_ok=True)
+
+
+def load_licenses() -> List[dict]:
+    """Load all license records from disk."""
+    if not LICENSE_FILE.exists():
+        return []
+    with LICENSE_FILE.open("r", encoding="utf-8") as fh:
+        return json.load(fh)
+
+
+def save_licenses(records: List[dict]) -> None:
+    """Persist license records to disk."""
+    _ensure_storage()
+    with LICENSE_FILE.open("w", encoding="utf-8") as fh:
+        json.dump(records, fh, indent=2)
+
+
+def generate_license(contract: str) -> LicenseRecord:
+    """Generate and store a new license key for ``contract``.
+
+    Returns the generated :class:`LicenseRecord`.
+    """
+    records = load_licenses()
+    key = secrets.token_hex(16)
+    record = {"key": key, "contract": contract}
+    records.append(record)
+    save_licenses(records)
+    return LicenseRecord(key=key, contract=contract)
+
+
+def verify_license(key: str) -> bool:
+    """Check whether ``key`` exists in stored licenses."""
+    return any(rec.get("key") == key for rec in load_licenses())

--- a/marketing/support_agreements.md
+++ b/marketing/support_agreements.md
@@ -16,3 +16,9 @@
 - **Includes:** Dedicated account manager and guaranteed SLA adherence
 
 *All tiers include access to documentation and product updates.*
+
+## Purchasing & Legal
+
+To purchase a support agreement or commercial license, email [sales@fractal-down.io](mailto:sales@fractal-down.io) with your desired tier.
+
+For legal inquiries or contract review, contact [legal@fractal-down.io](mailto:legal@fractal-down.io).

--- a/tests/test_license_key.py
+++ b/tests/test_license_key.py
@@ -1,0 +1,15 @@
+import importlib
+
+
+def test_generate_and_verify_license(tmp_path, monkeypatch):
+    license_path = tmp_path / "licenses.json"
+    monkeypatch.setenv("FRACTAL_DOWN_LICENSE_FILE", str(license_path))
+    lk = importlib.reload(importlib.import_module("fractal_down.license_key"))
+
+    record = lk.generate_license("contract-123")
+    assert record.contract == "contract-123"
+    assert lk.verify_license(record.key)
+    assert not lk.verify_license("invalid-key")
+
+    data = license_path.read_text()
+    assert record.key in data


### PR DESCRIPTION
## Summary
- document Apache vs. Fractal-Down license differences
- add purchase instructions and legal contacts to README and support docs
- implement simple license-key generation and verification via CLI

## Testing
- `pip install -e .[test]`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68afe8d2ed5c832284d30bbc48a6ff4b

## Summary by Sourcery

Introduce basic license key management and dual-license guidance by adding a new license_key module, integrating license commands into the CLI, updating documentation with licensing guidance and purchase steps, and adding tests for key issuance and verification.

New Features:
- Add license_key module for generating and storing license keys
- Extend CLI with 'license issue' and 'license check' commands

Enhancements:
- Expose license functions and LicenseRecord in package API

Documentation:
- Add license comparison guide between Apache 2.0 and Fractal-Down License
- Document purchase workflow and legal contacts in README and support docs

Tests:
- Add unit tests for license key generation and verification

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Added license key management to the CLI, including issuing and checking keys.
  - Introduced public APIs for generating and verifying license keys.

- Documentation
  - Added a Purchase section with steps to buy a commercial license and contact details for sales and legal inquiries.
  - Published a license comparison outlining differences between Apache 2.0 and the custom Fractal-Down License.
  - Expanded support agreements with purchasing and legal contact information.

- Tests
  - Added unit tests covering license issuance, verification, and on-disk persistence.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->