### PR TITLE
Add API endpoints with multitenant plan cache and billing hooks

### DIFF
--- a/README.md
+++ b/README.md
@@ -434,8 +434,11 @@ Results are saved to `artifacts/` with system information, detailed metrics, and
 
 ## Pricing
 
+Fractal-Down is launching a limited beta with pay-as-you-go pricing for early adopters.
+
 | Tier | Price | Features |
 |------|-------|----------|
+| Beta | Pay-as-you-go | Limited access, metered billing per plan build/run |
 | Community | Free | Open-source usage, community support |
 | Professional | $499/month | Standard support, email & Slack, early feature access |
 | Enterprise | Custom | Premium support, integration consulting, training workshops |

--- a/fractal_down/api.py
+++ b/fractal_down/api.py
@@ -1,0 +1,162 @@
+"""Simple FastAPI app exposing plan build/run endpoints."""
+
+from typing import Any, Dict, List, Optional, Tuple
+import operator
+
+from fastapi import Depends, FastAPI, HTTPException
+from pydantic import BaseModel, Field
+
+from .dag import DAG
+from .treelift import build_plan
+from .evaluator import Evaluator
+from .cache import get_or_build_plan
+
+# Registry of supported operations for JSON specs
+OP_REGISTRY = {
+    "add": operator.add,
+    "sub": operator.sub,
+    "mul": operator.mul,
+    "div": operator.truediv,
+}
+
+app = FastAPI()
+
+
+def set_billing_hook(app: FastAPI, hook) -> None:
+    """Configure a billing hook for this FastAPI app."""
+    app.state.billing_hook = hook
+
+
+def get_billing_hook():
+    return getattr(app.state, "billing_hook", None)
+
+
+class NodeSpec(BaseModel):
+    id: int
+    name: str
+    op: Optional[str] = None
+    inputs: List[int] = Field(default_factory=list)
+    meta: Dict[str, Any] = Field(default_factory=dict)
+
+
+class DAGSpec(BaseModel):
+    nodes: List[NodeSpec]
+    root: int
+
+
+class BuildRequest(BaseModel):
+    dag: DAGSpec
+    budget_nodes: int
+    tenant_id: str = Field(default="default", pattern=r"^[A-Za-z0-9._-]+$")
+
+
+class BuildResponse(BaseModel):
+    cache_path: str
+    was_cached: bool
+
+
+class RunRequest(BaseModel):
+    dag: DAGSpec
+    budget_nodes: int
+    inputs: Dict[str, Any]
+    tenant_id: str = Field(default="default", pattern=r"^[A-Za-z0-9._-]+$")
+
+
+class RunResponse(BaseModel):
+    result: Any
+    digest: str
+
+
+def _dag_from_spec(spec: DAGSpec) -> Tuple[DAG, int, Dict[str, int]]:
+    dag = DAG()
+    id_map: Dict[int, int] = {}
+    name_map: Dict[str, int] = {}
+
+    for node in spec.nodes:
+        if node.id in id_map:
+            raise ValueError(f"duplicate node id {node.id}")
+        if node.name in name_map:
+            raise ValueError(f"duplicate node name {node.name}")
+
+        resolved_inputs = []
+        for i in node.inputs:
+            if i not in id_map:
+                raise ValueError(f"unknown input id {i} for node {node.id}")
+            resolved_inputs.append(id_map[i])
+
+        if node.op is None:
+            node_id = dag.add_leaf(node.name, node.meta)
+        else:
+            try:
+                op = OP_REGISTRY[node.op]
+            except KeyError:
+                raise ValueError(f"unknown op {node.op}")
+            node_id = dag.add_op(node.name, op, resolved_inputs, node.meta)
+
+        id_map[node.id] = node_id
+        name_map[node.name] = node_id
+
+    if spec.root not in id_map:
+        raise ValueError("root node missing")
+    root_id = id_map[spec.root]
+    return dag, root_id, name_map
+
+
+@app.post("/plan/build", response_model=BuildResponse)
+async def plan_build(
+    req: BuildRequest, billing_hook=Depends(get_billing_hook)
+) -> BuildResponse:
+    try:
+        dag, root_id, _ = _dag_from_spec(req.dag)
+    except ValueError as e:
+        raise HTTPException(status_code=400, detail=str(e))
+
+    def build_fn():
+        return build_plan(dag, root_id, req.budget_nodes)
+
+    try:
+        plan, path, was_cached = get_or_build_plan(
+            dag,
+            root_id,
+            req.budget_nodes,
+            build_fn,
+            tenant_id=req.tenant_id,
+            billing_hook=billing_hook,
+        )
+    except ValueError as e:
+        raise HTTPException(status_code=400, detail=str(e))
+
+    return BuildResponse(cache_path=path, was_cached=was_cached)
+
+
+@app.post("/plan/run", response_model=RunResponse)
+async def plan_run(
+    req: RunRequest, billing_hook=Depends(get_billing_hook)
+) -> RunResponse:
+    try:
+        dag, root_id, name_map = _dag_from_spec(req.dag)
+    except ValueError as e:
+        raise HTTPException(status_code=400, detail=str(e))
+
+    try:
+        inputs = {name_map[k]: v for k, v in req.inputs.items()}
+    except KeyError as e:
+        raise HTTPException(status_code=400, detail=f"unknown input name {e.args[0]}")
+
+    def build_fn():
+        return build_plan(dag, root_id, req.budget_nodes)
+
+    try:
+        plan, _, _ = get_or_build_plan(
+            dag,
+            root_id,
+            req.budget_nodes,
+            build_fn,
+            tenant_id=req.tenant_id,
+            billing_hook=billing_hook,
+        )
+    except ValueError as e:
+        raise HTTPException(status_code=400, detail=str(e))
+
+    result = Evaluator(dag, inputs).run(plan)
+    return RunResponse(result=result.value, digest=result.digest.hex())

--- a/fractal_down/cache.py
+++ b/fractal_down/cache.py
@@ -6,9 +6,10 @@ and automatic cleanup of old entries.
 """
 
 import os
+import re
 import time
 from pathlib import Path
-from typing import Callable, Dict, Optional, Tuple
+from typing import Callable, Optional, Tuple
 
 from fractal_down.dag import DAG
 from fractal_down.fractal import FractalParams
@@ -17,14 +18,26 @@ from fractal_down.binary_plan import save_plan, load_plan
 from fractal_down.hashing import get_default_provider
 
 
-def get_cache_dir() -> Path:
-    """Get the plan cache directory, creating if necessary."""
+_TENANT_RE = re.compile(r"^[A-Za-z0-9._-]+$")
+
+
+def _sanitize_tenant_id(tenant_id: str) -> str:
+    """Validate tenant identifier to avoid path traversal."""
+    if not _TENANT_RE.fullmatch(tenant_id):
+        raise ValueError(f"invalid tenant id: {tenant_id!r}")
+    return tenant_id
+
+
+def get_cache_dir(tenant_id: str = "default") -> Path:
+    """Get the plan cache directory for a tenant, creating if necessary."""
+    tenant_id = _sanitize_tenant_id(tenant_id)
     cache_dir_str = os.environ.get("FRACTAL_DOWN_PLANS_DIR")
     if cache_dir_str:
-        cache_dir = Path(cache_dir_str)
+        root_dir = Path(cache_dir_str)
     else:
-        cache_dir = Path.home() / ".fractal_down" / "plans"
+        root_dir = Path.home() / ".fractal_down" / "plans"
 
+    cache_dir = root_dir / tenant_id
     cache_dir.mkdir(parents=True, exist_ok=True)
     return cache_dir
 
@@ -40,6 +53,9 @@ def get_or_build_plan(
     budget_nodes: int,
     build_fn: Callable[[], Plan],
     params: Optional[FractalParams] = None,
+    *,
+    tenant_id: str = "default",
+    billing_hook: Optional[Callable[[str, str], None]] = None,
 ) -> Tuple[Plan, str, bool]:
     """
     Get cached plan or build and cache a new one.
@@ -61,13 +77,15 @@ def get_or_build_plan(
     fingerprint = _generate_fingerprint(dag, root, budget_nodes, params)
 
     # Get cache directory and file path
-    cache_dir = get_cache_dir()
+    cache_dir = get_cache_dir(tenant_id)
     cache_file = cache_dir / f"{fingerprint}.fplan"
 
     # Try to load from cache
     if cache_file.exists():
         try:
             plan = load_plan(str(cache_file))
+            if billing_hook:
+                billing_hook(tenant_id, "hit")
             return plan, str(cache_file), True
         except (ValueError, IOError):
             # Cache file corrupted or invalid - remove it
@@ -87,7 +105,10 @@ def get_or_build_plan(
         pass
 
     # Clean up old cache entries
-    _cleanup_cache()
+    _cleanup_cache(cache_dir)
+
+    if billing_hook:
+        billing_hook(tenant_id, "miss")
 
     return plan, str(cache_file), False
 
@@ -170,9 +191,8 @@ def _canonicalize_dag(dag: DAG, root: int) -> str:
     return "|".join(node_strs)
 
 
-def _cleanup_cache():
+def _cleanup_cache(cache_dir: Path):
     """Clean up old cache entries, keeping only the newest MAX_KEEP files."""
-    cache_dir = get_cache_dir()
     max_keep = get_max_keep()
 
     try:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,14 +27,15 @@ dependencies = []
 
 [project.optional-dependencies]
 torch = ["torch"]
-test = ["pytest>=6.0"]
+test = ["pytest>=6.0", "fastapi>=0.110", "httpx>=0.24"]
 bench = [
-    "psutil>=5.9", 
-    "matplotlib>=3.7", 
-    "pandas>=2.0; python_version >= '3.10'", 
-    "pynvml>=11.5; platform_system=='Linux' or platform_system=='Windows'", 
+    "psutil>=5.9",
+    "matplotlib>=3.7",
+    "pandas>=2.0; python_version >= '3.10'",
+    "pynvml>=11.5; platform_system=='Linux' or platform_system=='Windows'",
     "pyRAPL>=0.3; platform_system=='Linux'"
 ]
+api = ["fastapi>=0.110", "uvicorn>=0.23"]
 
 [project.urls]
 Homepage = "https://github.com/nwoolr20/Fractal-Down"

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,4 +3,4 @@
 # Uses pyproject.toml as the single source of truth
 
 # Install package in editable mode with all optional dependencies
--e .[test,bench,torch]
+-e .[test,bench,torch,api]

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1,0 +1,99 @@
+import os
+import tempfile
+from fastapi.testclient import TestClient
+
+from fractal_down.api import app, set_billing_hook
+
+
+def test_api_build_and_run():
+    with tempfile.TemporaryDirectory() as tmpdir:
+        os.environ["FRACTAL_DOWN_PLANS_DIR"] = tmpdir
+        try:
+            client = TestClient(app)
+
+            spec = {
+                "nodes": [
+                    {"id": 1, "name": "a", "op": None, "inputs": []},
+                    {"id": 2, "name": "b", "op": None, "inputs": []},
+                    {"id": 3, "name": "c", "op": "add", "inputs": [1, 2]},
+                ],
+                "root": 3,
+            }
+
+            events = []
+
+            def hook(tenant, event):
+                events.append((tenant, event))
+
+            set_billing_hook(app, hook)
+
+            resp = client.post(
+                "/plan/build",
+                json={"dag": spec, "budget_nodes": 2, "tenant_id": "beta"},
+            )
+            assert resp.status_code == 200
+            assert resp.json()["was_cached"] is False
+
+            resp2 = client.post(
+                "/plan/build",
+                json={"dag": spec, "budget_nodes": 2, "tenant_id": "beta"},
+            )
+            assert resp2.json()["was_cached"] is True
+
+            run_resp = client.post(
+                "/plan/run",
+                json={
+                    "dag": spec,
+                    "budget_nodes": 2,
+                    "tenant_id": "beta",
+                    "inputs": {"a": 2, "b": 3},
+                },
+            )
+            assert run_resp.status_code == 200
+            body = run_resp.json()
+            assert body["result"] == 5
+            assert isinstance(body["digest"], str) and len(body["digest"]) == 64
+
+            assert events == [("beta", "miss"), ("beta", "hit"), ("beta", "hit")]
+        finally:
+            del os.environ["FRACTAL_DOWN_PLANS_DIR"]
+
+
+def test_api_rejects_invalid_spec_and_inputs():
+    client = TestClient(app)
+
+    dup_spec = {
+        "nodes": [
+            {"id": 1, "name": "a", "op": None, "inputs": []},
+            {"id": 1, "name": "b", "op": None, "inputs": []},
+        ],
+        "root": 1,
+    }
+    resp = client.post("/plan/build", json={"dag": dup_spec, "budget_nodes": 1})
+    assert resp.status_code == 400
+
+    missing_spec = {
+        "nodes": [
+            {"id": 1, "name": "a", "op": "add", "inputs": [2]},
+        ],
+        "root": 1,
+    }
+    resp2 = client.post("/plan/build", json={"dag": missing_spec, "budget_nodes": 1})
+    assert resp2.status_code == 400
+
+    valid_spec = {
+        "nodes": [
+            {"id": 1, "name": "a", "op": None, "inputs": []},
+            {"id": 2, "name": "b", "op": None, "inputs": []},
+        ],
+        "root": 1,
+    }
+    bad_run = client.post(
+        "/plan/run",
+        json={
+            "dag": valid_spec,
+            "budget_nodes": 1,
+            "inputs": {"missing": 1},
+        },
+    )
+    assert bad_run.status_code == 400

--- a/tests/test_multitenant_cache.py
+++ b/tests/test_multitenant_cache.py
@@ -1,0 +1,89 @@
+import os
+import tempfile
+
+import pytest
+
+from fractal_down.dag import DAG
+from fractal_down.treelift import build_plan
+from fractal_down.cache import get_or_build_plan
+
+
+def test_multitenant_cache_isolated_and_billing():
+    dag = DAG()
+    a = dag.add_leaf("a")
+
+    def build_fn():
+        return build_plan(dag, a, budget_nodes=1)
+
+    events = []
+
+    def hook(tenant, event):
+        events.append((tenant, event))
+
+    with tempfile.TemporaryDirectory() as tmpdir:
+        os.environ["FRACTAL_DOWN_PLANS_DIR"] = tmpdir
+        try:
+            get_or_build_plan(dag, a, 1, build_fn, tenant_id="t1", billing_hook=hook)
+            get_or_build_plan(dag, a, 1, build_fn, tenant_id="t2", billing_hook=hook)
+            # Second call for tenant t1 should hit cache
+            get_or_build_plan(dag, a, 1, build_fn, tenant_id="t1", billing_hook=hook)
+
+            tenant_dirs = {p.name for p in os.scandir(tmpdir) if p.is_dir()}
+            assert tenant_dirs == {"t1", "t2"}
+            assert events == [("t1", "miss"), ("t2", "miss"), ("t1", "hit")]
+        finally:
+            del os.environ["FRACTAL_DOWN_PLANS_DIR"]
+
+
+def test_multitenant_cache_eviction_per_tenant():
+    dag = DAG()
+    a = dag.add_leaf("a")
+
+    def build_fn(dag, leaf):
+        return build_plan(dag, leaf, budget_nodes=1)
+
+    with tempfile.TemporaryDirectory() as tmpdir:
+        os.environ["FRACTAL_DOWN_PLANS_DIR"] = tmpdir
+        os.environ["FRACTAL_DOWN_PLAN_MAX_KEEP"] = "3"
+        try:
+            # Fill cache for tenant1 with unique dags
+            for i in range(3):
+                d = DAG()
+                leaf = d.add_leaf(f"x{i}")
+                get_or_build_plan(d, leaf, 1, lambda d=d, leaf=leaf: build_fn(d, leaf), tenant_id="tenant1")
+
+            # Trigger eviction
+            d_ev = DAG()
+            leaf_ev = d_ev.add_leaf("evict")
+            _, path4, _ = get_or_build_plan(d_ev, leaf_ev, 1, lambda d=d_ev, leaf=leaf_ev: build_fn(d, leaf), tenant_id="tenant1")
+
+            tenant_dir = os.path.join(tmpdir, "tenant1")
+            files = [f for f in os.listdir(tenant_dir) if f.endswith(".fplan")]
+            assert len(files) == 3
+            assert os.path.basename(path4) in files
+
+            # Other tenant unaffected
+            d2 = DAG()
+            l2 = d2.add_leaf("y")
+            get_or_build_plan(d2, l2, 1, lambda d=d2, leaf=l2: build_fn(d, leaf), tenant_id="tenant2")
+            tenant2_dir = os.path.join(tmpdir, "tenant2")
+            assert len([f for f in os.listdir(tenant2_dir) if f.endswith(".fplan")]) == 1
+        finally:
+            del os.environ["FRACTAL_DOWN_PLANS_DIR"]
+            del os.environ["FRACTAL_DOWN_PLAN_MAX_KEEP"]
+
+
+def test_invalid_tenant_id_rejected():
+    dag = DAG()
+    a = dag.add_leaf("a")
+
+    def build_fn():
+        return build_plan(dag, a, budget_nodes=1)
+
+    with tempfile.TemporaryDirectory() as tmpdir:
+        os.environ["FRACTAL_DOWN_PLANS_DIR"] = tmpdir
+        try:
+            with pytest.raises(ValueError):
+                get_or_build_plan(dag, a, 1, build_fn, tenant_id="../evil")
+        finally:
+            del os.environ["FRACTAL_DOWN_PLANS_DIR"]

--- a/tests/test_requirements.py
+++ b/tests/test_requirements.py
@@ -56,7 +56,7 @@ def test_main_requirements_includes_all():
         content = f.read()
 
     # Should include reference to pyproject.toml with all extras
-    assert "-e .[test,bench,torch]" in content
+    assert "-e .[test,bench,torch,api]" in content
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- expose FastAPI service for plan build and run
- support multitenant cache directories with billing callbacks
- document beta pay-as-you-go tier and include api dependencies

## Testing
- `pip install -e .[test,api]` *(failed: `pyRAPL` unavailable)*
- `pytest tests/test_api.py tests/test_multitenant_cache.py`


------
https://chatgpt.com/codex/tasks/task_e_68afed0b825c832288602004bbce41ba

## Summary by Sourcery

Add a FastAPI-based HTTP API for plan building and running, implement multitenant cache directories with billing callbacks, and update dependencies, documentation, and tests to support the new API and caching behavior

New Features:
- Expose FastAPI endpoints at /plan/build and /plan/run for plan creation and execution
- Introduce billing hook support to report cache hits and misses

Enhancements:
- Enable multitenant plan caching with tenant ID sanitization and isolated cache directories
- Perform cache cleanup per-tenant instead of a global cache
- Add 'api' extra dependencies in pyproject.toml for FastAPI and Uvicorn

Documentation:
- Document beta pay-as-you-go pricing tier in the README

Tests:
- Add API endpoint tests covering build, run, input validation, and billing events
- Add multitenant cache tests for isolation, eviction policy, and invalid tenant IDs
- Update test requirements to include the 'api' extras

Chores:
- Update requirements.txt and test_requirements to install the 'api' extras

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* New Features
  * Introduced an HTTP API to build and run plans from DAG specifications, with validation and clear error responses.
  * Added per-tenant plan caching for isolation; optional billing hooks report cache hit/miss events.
* Documentation
  * Updated Pricing with a new Beta tier and note on limited pay-as-you-go beta.
* Chores
  * Added optional API dependencies and updated test dependencies; installation extras now include “api”.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->